### PR TITLE
Document notificationHook in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Type `/speak` to verify the plugin is loaded. Key commands:
 /speak set sentences 2 # sentences per response (1-10)
 /speak terse           # strip markdown before speaking
 /speak voices          # list available voices
+/speak set notificationHook off                             # silence idle/permission pings
+/speak set notificationHook on                              # re-enable (restores last behavior)
+/speak set notificationHook speak                           # TTS the notification (default)
+/speak set notificationHook /System/Library/Sounds/Blow.aiff # play a sound instead (macOS)
 ```
 
 Full command reference: [skills/speak/SKILL.md](skills/speak/SKILL.md)
@@ -56,6 +60,8 @@ Full command reference: [skills/speak/SKILL.md](skills/speak/SKILL.md)
 ## How it works
 
 A Stop hook fires after each Claude response. The text is cleaned (markdown stripped), truncated to N sentences, and spoken by the platform's native TTS engine. If a previous response is still speaking, it gets cut off. No additional tokens are consumed -- this is pure client-side TTS.
+
+A second Notification hook fires on permission prompts and idle pings. It is configurable via `/speak set notificationHook`: turn it `off` for silence, leave it `on` to TTS the message, or point it at an absolute sound-file path (e.g. `/System/Library/Sounds/Blow.aiff`) to play a sound instead. Sound playback is macOS-only in the current pass.
 
 The engine interface is at `lib/engine.mjs` if you want to swap in a different runtime.
 


### PR DESCRIPTION
## Summary
- Adds the four `/speak set notificationHook` forms to the Usage block
- Adds a short paragraph under "How it works" explaining the Notification hook modes (speak / off / sound-file, macOS sound only this pass)

Follow-up to #4. Refs #3.

## Test plan
- [ ] README renders cleanly on GitHub
- [ ] Commands shown match the actual surface in `skills/speak/SKILL.md`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>